### PR TITLE
[Feat] 형태소 기반 TF-IDF 모델 구현

### DIFF
--- a/notebooks/Best_TFIDF_XGBoost_Optimized.ipynb
+++ b/notebooks/Best_TFIDF_XGBoost_Optimized.ipynb
@@ -1,0 +1,168 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "9c7f4846",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 📚 라이브러리 불러오기\n",
+    "import pandas as pd\n",
+    "import re\n",
+    "import time\n",
+    "from konlpy.tag import Okt\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.feature_extraction.text import TfidfVectorizer\n",
+    "from xgboost import XGBClassifier\n",
+    "from sklearn.metrics import roc_auc_score\n",
+    "\n",
+    "okt = Okt()\n",
+    "\n",
+    "def tokenize_morphs(text):\n",
+    "    return \" \".join(okt.morphs(str(text)))\n",
+    "\n",
+    "def extract_features(text):\n",
+    "    text = str(text)\n",
+    "    features = {\n",
+    "        \"length_chars\": len(text),\n",
+    "        \"length_words\": len(text.split()),\n",
+    "        \"num_commas\": text.count(\",\"),\n",
+    "        \"num_periods\": text.count(\".\"),\n",
+    "        \"avg_word_len\": sum(len(w) for w in text.split()) / len(text.split()) if text.split() else 0,\n",
+    "        \"num_uppercase\": sum(c.isupper() for c in text),\n",
+    "        \"num_digits\": sum(c.isdigit() for c in text),\n",
+    "        \"num_punctuations\": len(re.findall(r'[^\\w\\s]', text)),\n",
+    "    }\n",
+    "    return pd.Series(features)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "95057bb7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "형태소 분석 중...\n",
+      "TF-IDF 벡터화 중...\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 🔹 데이터 불러오기\n",
+    "df = pd.read_csv(\"open/train.csv\")\n",
+    "\n",
+    "print(\"형태소 분석 중...\")\n",
+    "df[\"full_text_morph\"] = df[\"full_text\"].apply(tokenize_morphs)\n",
+    "df_features = df[\"full_text\"].apply(extract_features)\n",
+    "\n",
+    "print(\"TF-IDF 벡터화 중...\")\n",
+    "vectorizer = TfidfVectorizer(max_features=2000)\n",
+    "X_tfidf = vectorizer.fit_transform(df[\"full_text_morph\"])\n",
+    "\n",
+    "X_all = pd.concat([pd.DataFrame(X_tfidf.toarray()), df_features.reset_index(drop=True)], axis=1)\n",
+    "y_all = df[\"generated\"]\n",
+    "\n",
+    "# 🔹 AI:사람 = 1:2 비율 샘플링\n",
+    "df_ai = X_all[df[\"generated\"] == 1]\n",
+    "df_human = X_all[df[\"generated\"] == 0].sample(n=len(df_ai)*2, random_state=42)\n",
+    "X_balanced = pd.concat([df_ai, df_human])\n",
+    "y_balanced = pd.Series([1]*len(df_ai) + [0]*len(df_human))\n",
+    "\n",
+    "X_train, X_val, y_train, y_val = train_test_split(X_balanced, y_balanced, test_size=0.2, random_state=42, stratify=y_balanced)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "41c32e97",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "모델 학습 중...\n",
+      "✅ Validation ROC AUC: 0.93042\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"모델 학습 중...\")\n",
+    "model = XGBClassifier(\n",
+    "    scale_pos_weight=(y_train == 0).sum() / (y_train == 1).sum(),\n",
+    "    n_estimators=300,\n",
+    "    learning_rate=0.05,\n",
+    "    max_depth=6,\n",
+    "    random_state=42,\n",
+    "    tree_method=\"hist\"\n",
+    ")\n",
+    "model.fit(X_train, y_train)\n",
+    "\n",
+    "y_pred_proba = model.predict_proba(X_val)[:, 1]\n",
+    "roc_score = roc_auc_score(y_val, y_pred_proba)\n",
+    "print(\"✅ Validation ROC AUC:\", round(roc_score, 5))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "2593b58d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "테스트셋 형태소 분석 중...\n",
+      "테스트셋 예측 중...\n",
+      "🎉 제출 완료: submission_best_tfidf_tuned.csv\n"
+     ]
+    }
+   ],
+   "source": [
+    "test_df = pd.read_csv(\"open/test.csv\")\n",
+    "test_df = test_df.rename(columns={\"paragraph_text\": \"full_text\"})\n",
+    "\n",
+    "print(\"테스트셋 형태소 분석 중...\")\n",
+    "test_df[\"full_text_morph\"] = test_df[\"full_text\"].apply(tokenize_morphs)\n",
+    "test_features = test_df[\"full_text\"].apply(extract_features)\n",
+    "test_tfidf = vectorizer.transform(test_df[\"full_text_morph\"])\n",
+    "test_all = pd.concat([pd.DataFrame(test_tfidf.toarray()), test_features.reset_index(drop=True)], axis=1)\n",
+    "\n",
+    "print(\"테스트셋 예측 중...\")\n",
+    "test_probs = model.predict_proba(test_all)[:, 1]\n",
+    "\n",
+    "submission = pd.read_csv(\"open/sample_submission.csv\")\n",
+    "submission[\"generated\"] = test_probs\n",
+    "submission.to_csv(\"submission_best_tfidf_tuned.csv\", index=False)\n",
+    "print(\"🎉 제출 완료: submission_best_tfidf_tuned.csv\")\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "hf-env",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## 🪡 Pull Request

### Overview  
형태소 분석 기반으로 TF-IDF 벡터와 수치 피처를 결합한 XGBoost 모델을 구현했습니다.  
- **Validation ROC AUC**: 0.93042 (샘플 기준)  
- **대회 제출 점수**: 0.61812719 (`submission_morph_tfidf.csv`)

### Change Log  
- `Okt` 형태소 분석기를 이용해 `full_text_morph` 열 생성  
- TF-IDF 벡터화 (상위 2000개 토큰 기준)  
- 글자 수, 단어 수, 숫자/대문자/구두점 개수 등의 수치 피처 추가  
- AI:Human = 1:2 비율로 샘플링 후 XGBoost 학습  
- 제출 파일(`submission_morph_tfidf.csv`) 생성 및 저장

### To Reviewer  
모델은 빠르게 실행 가능하지만 baseline 대비 성능은 낮음.